### PR TITLE
feat: add template notebook

### DIFF
--- a/{{cookiecutter.directory_name}}/notebook/notebook.ipynb
+++ b/{{cookiecutter.directory_name}}/notebook/notebook.ipynb
@@ -1,0 +1,41 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import plotly.express as px\n",
+    "\n",
+    "import sys\n",
+    "sys.path.append('../') \n",
+    "from scripts.utils import show_fig, sql_query"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = sql_query('sql/nome_do_arquivo.sql', update_result=False)\n",
+    "df.head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/{{cookiecutter.directory_name}}/notebook/notebook.ipynb
+++ b/{{cookiecutter.directory_name}}/notebook/notebook.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = sql_query('sql/nome_do_arquivo.sql', update_result=False)\n",
+    "df = sql_query('sql/{{cookiecutter.directory_name}}.sql', update_result=False)\n",
     "df.head()"
    ]
   }
@@ -32,7 +32,15 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
    "version": "3.11.7"
   }
  },

--- a/{{cookiecutter.directory_name}}/sql/{{cookiecutter.directory_name}}.sql
+++ b/{{cookiecutter.directory_name}}/sql/{{cookiecutter.directory_name}}.sql
@@ -1,0 +1,2 @@
+-- Esse é um arquivo exemplo. Você pode alterar o conteúdo dele para a query desejada ou deletá-lo.
+select 'Hello, World!' as message;


### PR DESCRIPTION
Adiciona um notebook template importando as bibliotecas mais comumente utilizadas e deixando preparado o procedimento padrão de rodar a query SQL.
Não tenho certeza se é uma modificação útil para todo mundo, mas pelo menos aqui do meu lado adiantaria bastante (sempre volto nos notebooks antigos pra copiar as duas primeiras células).

Deixo aberto para edições e comentários para outras melhorias! 